### PR TITLE
add bullet_action arg in _create_bullet_group

### DIFF
--- a/game/packages/thlib-scripts/THlib/editor.lua
+++ b/game/packages/thlib-scripts/THlib/editor.lua
@@ -444,7 +444,7 @@ function _straight:frame()
     end
 end
 
-function _create_bullet_group(style, color, x, y, n, t, v1, v2, angle, da, aim, omiga, stay, des, time, _495, enemy)
+function _create_bullet_group(style, color, x, y, n, t, v1, v2, angle, da, aim, omiga, stay, des, time, _495, enemy, bullet_action)
     local unitlist = {}
     local p = player
     if n >= 1 then
@@ -457,9 +457,17 @@ function _create_bullet_group(style, color, x, y, n, t, v1, v2, angle, da, aim, 
             if aim then
                 angle = angle + Angle(x, y, p.x, p.y)
             end
-            for i = 0, n - 1 do
-                local last1 = New(_straight, style, color, x, y, v1 + dv * i, angle + da * i, false, omiga, stay, des, time, _495)
-                ex.UnitListAppend(unitlist, last1)
+            if type(bullet_action) == "function" then
+                for i = 0, n - 1 do
+                    local last1 = New(_straight, style, color, x, y, v1 + dv * i, angle + da * i, false, omiga, stay, des, time, _495)
+                    ex.UnitListAppend(unitlist, last1)
+                    bullet_action(last1, i)
+                end
+            else
+                for i = 0, n - 1 do
+                    local last1 = New(_straight, style, color, x, y, v1 + dv * i, angle + da * i, false, omiga, stay, des, time, _495)
+                    ex.UnitListAppend(unitlist, last1)
+                end
             end
             last = unitlist
             return unitlist
@@ -473,10 +481,19 @@ function _create_bullet_group(style, color, x, y, n, t, v1, v2, angle, da, aim, 
             if aim then
                 angle = angle + Angle(x, y, p.x, p.y)
             end
-            for i = 0, n - 1 do
-                local last1 = New(_straight, style, color, x, y, v1 + dv * i, angle + da * i, false, omiga, stay, des, time, _495)
-                ex.UnitListAppend(unitlist, last1)
-                task._Wait(t)
+            if type(bullet_action) == "function" then
+                for i = 0, n - 1 do
+                    local last1 = New(_straight, style, color, x, y, v1 + dv * i, angle + da * i, false, omiga, stay, des, time, _495)
+                    ex.UnitListAppend(unitlist, last1)
+                    bullet_action(last1, i)
+                    task._Wait(t)
+                end
+            else
+                for i = 0, n - 1 do
+                    local last1 = New(_straight, style, color, x, y, v1 + dv * i, angle + da * i, false, omiga, stay, des, time, _495)
+                    ex.UnitListAppend(unitlist, last1)
+                    task._Wait(t)
+                end
             end
         end, enemy)
     end


### PR DESCRIPTION
This pull request includes changes to the `game/packages/thlib-scripts/THlib/editor.lua` file to enhance the functionality of the `_create_bullet_group` function by adding support for a custom bullet action.

Enhancements to `_create_bullet_group` function:

* Added a new `bullet_action` parameter to the `_create_bullet_group` function signature.
* Implemented conditional logic to check if `bullet_action` is a function and, if so, apply it to each bullet created within the loop. This allows for custom actions to be executed on each bullet. [[1]](diffhunk://#diff-bcbff0a378a0c5bf558d63e8babcd26c1fc55b34a058e4c1deac52f6eb9a37deR460-R470) [[2]](diffhunk://#diff-bcbff0a378a0c5bf558d63e8babcd26c1fc55b34a058e4c1deac52f6eb9a37deR484-R497)