### PR TITLE
增加关卡额外数据记录集，修正boss击破时间记录值

### DIFF
--- a/game/packages/thlib-scripts/THlib/enemy/boss_system.lua
+++ b/game/packages/thlib-scripts/THlib/enemy/boss_system.lua
@@ -3,7 +3,6 @@
 ---@return lstg.StopWatch
 local StopWatch = plus.Class()
 
-
 ---初始化函数
 function StopWatch:init()
     self:Reset()
@@ -739,8 +738,18 @@ function system:popSpellResult()
         b._timer = b.timer
         b._timeout = b.timeout
     end
-    local t = self.clock:GetElapsed() * time_rate
-    b._real_timer = t
+    local tmpvar = lstg.tmpvar
+    local timerRecordIndex = (tmpvar.timer_record_index or 0) + 1
+    tmpvar.timer_record_index = timerRecordIndex
+    local timerRecordName = table.concat({ "boss_timer", timerRecordIndex }, "|")
+    if ext.replay.IsReplay() then
+        local t = ext.stage_data.GetStageData(timerRecordName)
+        b._real_timer = t or 0
+    else
+        local t = self.clock:GetElapsed() * time_rate
+        ext.stage_data.SetStageData(timerRecordName, t)
+        b._real_timer = t
+    end
     b.timeout = nil
     self:finishSpellHist(b._getcard)
     local c = {}
@@ -838,7 +847,7 @@ function system:refresh(part)
         b._sp_point_auto = {}
         b.__is_waiting = true
         b.__hpbartype = -1
-        self.is_killing = false 
+        self.is_killing = false
     end
 end
 

--- a/game/packages/thlib-scripts/THlib/ext/ext.lua
+++ b/game/packages/thlib-scripts/THlib/ext/ext.lua
@@ -21,6 +21,8 @@ DoFile(extpath .. "ext_replay.lua")
  --CHU爷爷的replay系统以及切关函数重载
 DoFile(extpath .. "ext_stage_group.lua")
  --关卡组
+DoFile(extpath .. "ext_stage_data.lua")
+ --关卡数据
 
 ext.replayTicker = 0
  --控制录像播放速度时有用
@@ -178,6 +180,8 @@ function ChangeGameStage()
         lstg.var = lstg.nextvar
         lstg.nextvar = nil
     end
+
+    ext.stage_data.InitStageData()
 
     -- 初始化随机数
     if lstg.var.ran_seed then

--- a/game/packages/thlib-scripts/THlib/ext/ext_stage_data.lua
+++ b/game/packages/thlib-scripts/THlib/ext/ext_stage_data.lua
@@ -1,0 +1,87 @@
+----------------------------------------
+--- extra stage data
+
+---@type table<string|number,string|number|boolean>|nil
+local extraData
+
+---@type table<string|number,string|number|boolean>|nil
+local nextData
+
+ext.stage_data = {}
+
+---检查 key 的类型是否合法
+---@param key any
+---@return boolean
+local function checkKeyType(key)
+    local keyType = type(key)
+    if keyType == "string" or keyType == "number" then
+        return true
+    else
+        lstg.Log(2, string.format("Invalid key type: %s", keyType))
+        return false, string.format("Key must be a string or number, got %s", keyType)
+    end
+end
+
+---检查 value 的类型是否合法
+---@param value any
+---@return boolean
+local function checkValueType(value)
+    local valueType = type(value)
+    if valueType == "string" or valueType == "number" or valueType == "boolean" then
+        return true
+    else
+        lstg.Log(2, string.format("Invalid value type: %s", valueType))
+        return false, string.format("Value must be a string, number, or boolean, got %s", valueType)
+    end
+end
+
+---设置关卡数据
+---@param key string|number
+---@param value string|number|boolean
+function ext.stage_data.SetStageData(key, value)
+    if ext.replay.IsReplay() then
+        error("Cannot set stage data in replay mode")
+        return
+    end
+
+    assert(extraData, "extraData is not initialized")
+    assert(checkKeyType(key))
+    assert(checkValueType(value))
+    extraData[key] = value
+end
+
+---获取关卡数据
+---@param key string|number
+---@return string|number|boolean|nil
+function ext.stage_data.GetStageData(key)
+    assert(extraData, "extraData is not initialized")
+    assert(checkKeyType(key))
+    return extraData[key]
+end
+
+---装载关卡数据
+function ext.stage_data.InitStageData()
+    if nextData then
+        -- 如果 nextData 已经存在，直接使用它
+        extraData = nextData
+        nextData = nil
+    else
+        -- 否则初始化一个新的空表
+        extraData = {}
+    end
+end
+
+---序列化关卡数据
+---@return string
+function ext.stage_data.SerializeStageData()
+    assert(extraData, "extraData is not initialized")
+    return Serialize(extraData)
+end
+
+---准备关卡数据
+---@param data string
+function ext.stage_data.PrepareStageData(data)
+    assert(type(data) == "string", "Data must be a serialized string")
+    nextData = DeSerialize(data)
+    assert(type(nextData) == "table", "Deserialized data must be a table")
+end


### PR DESCRIPTION
This pull request introduces a new system for managing extra stage data in the game, along with enhancements to the replay system to support storing and retrieving this data. The changes include the addition of a new module `ext_stage_data.lua`, modifications to existing replay and stage management functions, and integration of the new system into the game's workflow.

### New system for managing extra stage data:
* [`game/packages/thlib-scripts/THlib/ext/ext_stage_data.lua`](diffhunk://#diff-12bf5f28a368fbfbe29d1bb86281b0075b51d0eb92bae4f28ba9f02db2aa918fR1-R87): Added a new module `ext.stage_data` to handle extra stage data, including methods for setting, retrieving, initializing, serializing, and preparing stage data. This module ensures type validation for keys and values and prevents data modification during replay mode.

### Replay system enhancements:
* [`game/packages/thlib-scripts/THlib/ext/ext_replay.lua`](diffhunk://#diff-eb041bff0170bc49894dc6ab09fa0e2075b6ec9697d881a2cc7bd8e2cec1b9a5R64-R70): Updated `SaveReplay` to store serialized stage data in the `gameExtendInfo` field and added logic in `stage.Set` to prepare stage data from replay files when available. [[1]](diffhunk://#diff-eb041bff0170bc49894dc6ab09fa0e2075b6ec9697d881a2cc7bd8e2cec1b9a5R64-R70) [[2]](diffhunk://#diff-eb041bff0170bc49894dc6ab09fa0e2075b6ec9697d881a2cc7bd8e2cec1b9a5R80) [[3]](diffhunk://#diff-eb041bff0170bc49894dc6ab09fa0e2075b6ec9697d881a2cc7bd8e2cec1b9a5L129-R133) [[4]](diffhunk://#diff-eb041bff0170bc49894dc6ab09fa0e2075b6ec9697d881a2cc7bd8e2cec1b9a5R229-R237)

### Integration of extra stage data into the game workflow:
* [`game/packages/thlib-scripts/THlib/ext/ext.lua`](diffhunk://#diff-a719737813a906f8dd29ab63d88cdefed21c82708e1332f72ed9fc31ad5933c0R24-R25): Integrated the new `ext.stage_data` module into the game by loading it in the initialization script and calling `InitStageData` during stage transitions. [[1]](diffhunk://#diff-a719737813a906f8dd29ab63d88cdefed21c82708e1332f72ed9fc31ad5933c0R24-R25) [[2]](diffhunk://#diff-a719737813a906f8dd29ab63d88cdefed21c82708e1332f72ed9fc31ad5933c0R184-R185)

### Additional changes:
* [`game/packages/thlib-scripts/THlib/enemy/boss_system.lua`](diffhunk://#diff-0da27abc6a2a78c5a5c1b974c3222c287ad1240d75e15c3c97cd72b79e757009R741-R752): Added logic to record and retrieve boss timer data using the new `ext.stage_data` system, ensuring compatibility with replay mode.