### PR TITLE
增加安全模式保存功能及相关代码的改进

### DIFF
--- a/game/packages/thlib-scripts/foundation/legacy/scoredata.lua
+++ b/game/packages/thlib-scripts/foundation/legacy/scoredata.lua
@@ -45,7 +45,7 @@ scoredata = nil -- TODO: 铲掉这个屎山
 
 function SaveScoreData()
     if global_data_storage then
-        global_data_storage:save()
+        global_data_storage:save(false, true)
     end
 end
 

--- a/game/packages/thlib-scripts/foundation/legacy/setting.lua
+++ b/game/packages/thlib-scripts/foundation/legacy/setting.lua
@@ -1,6 +1,7 @@
 local cjson_util = require("cjson.util")
 local default_setting = require("foundation.legacy.default_setting")
 local LocalFileStorage = require("foundation.LocalFileStorage")
+local DataStorage = require("foundation.DataStorage")
 
 local function get_file_name()
 	return LocalFileStorage.getRootDirectory() .. "/setting.json"
@@ -10,77 +11,30 @@ local function get_file_name_launch()
 	return LocalFileStorage.getRootDirectory() .. "/config.launch.json"
 end
 
-local function safe_encode_json(t)
-	local r, e = pcall(cjson.encode, t)
-	if r then
-		return e
-	else
-		lstg.Log(4, "encode table to json failed: " .. tostring(e))
-		return cjson.encode(default_setting)
-	end
-end
-
-local function safe_decode_json(s)
-	local r, e = pcall(cjson.decode, s)
-	if r then
-		return e
-	else
-		lstg.Log(4, "decode json to table failed: " .. tostring(e))
-		return cjson.decode(cjson.encode(s)) -- copy
-	end
-end
-
-local function write_file(path, content)
-	local f = assert(io.open(path, "w"))
-	f:write(content)
-	f:close()
-end
+---@type foundation.DataStorage
+local setting_storage, launch_storage
 
 function loadConfigure()
-	local f, msg
-	f, msg = io.open(get_file_name(), 'r')
-	if f == nil then
-		setting = safe_decode_json(safe_encode_json(default_setting))
-	else
-		setting = safe_decode_json(f:read('*a'))
-		f:close()
-	end
+	setting_storage = DataStorage.open(get_file_name(), default_setting)
+	setting = setting_storage:root()
 end
 
 function saveConfigure()
-	local content = cjson_util.format_json(safe_encode_json(setting))
-	write_file(get_file_name(), content)
-	local content_launch = cjson_util.format_json(safe_encode_json({
-		graphics_system = {
-			width = setting.resx,
-			height = setting.resy,
-			fullscreen = not setting.windowed,
-			vsync = setting.vsync,
-		},
-		audio_system = {
-			sound_effect_volume = setting.sevolume / 100.0,
-			music_volume = setting.bgmvolume / 100.0,
-		},
-	}))
-	write_file(get_file_name_launch(), content_launch)
-end
+	setting_storage:save(true, true)
 
-function loadConfigureTable()
-	local f, msg
-	f, msg = io.open(get_file_name(), 'r')
-	if f == nil then
-		local t = safe_decode_json(safe_encode_json(default_setting))
-		return t
-	else
-		local t = safe_decode_json(f:read('*a'))
-		f:close()
-		return t
-	end
-end
-
-function saveConfigureTable(t)
-	local content = cjson_util.format_json(safe_encode_json(t))
-	write_file(get_file_name(), content)
+	launch_storage = DataStorage.open(get_file_name_launch())
+	local launch_content = launch_storage:root()
+	launch_content.graphics_system = {
+		width = setting.resx,
+		height = setting.resy,
+		fullscreen = not setting.windowed,
+		vsync = setting.vsync,
+	}
+	launch_content.audio_system = {
+		sound_effect_volume = setting.sevolume / 100.0,
+		music_volume = setting.bgmvolume / 100.0,
+	}
+	launch_storage:save(true, true)
 end
 
 loadConfigure() -- 先加载一次配置


### PR DESCRIPTION
- 在 DataStorage 类的 save 方法中添加 safemode 参数
- DataStorage 中增加可以保存纯文本的函数 save_text
- 在安全模式下，先将数据写入临时文件，然后替换原文件
- 修改 SaveScoreData 函数，使用安全模式保存数据
- setting.lua 接入 DataStorage